### PR TITLE
Fix event subscription annotation package import

### DIFF
--- a/src/main/resources/archetype-resources/src/main/java/MyPlugin.java
+++ b/src/main/resources/archetype-resources/src/main/java/MyPlugin.java
@@ -12,7 +12,7 @@ import org.spongepowered.api.event.state.PreInitializationEvent;
 import org.spongepowered.api.event.state.ServerStoppingEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.service.config.DefaultConfig;
-import org.spongepowered.api.util.event.Subscribe;
+import org.spongepowered.api.event.Subscribe;
 
 /**
  * PermissionsEx plugin


### PR DESCRIPTION
Without this change, couldn't get the plugin generated by this archetype to compile, failed to find the Subscribe class:

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12.770s
[INFO] Finished at: Mon Apr 13 20:07:52 PDT 2015
[INFO] Final Memory: 13M/245M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project SampleSpongePlugin: Compilation failure: Compilation failure:
[ERROR] /Users/admin/minecraft/SampleSpongePlugin/src/main/java/io/github/deathcap/MyPlugin.java:[12,39] error: cannot find symbol
[ERROR] 
[ERROR] could not parse error message:   symbol:   class Subscribe
[ERROR] location: package org.spongepowered.api.util.event
[ERROR] /Users/admin/minecraft/SampleSpongePlugin/src/main/java/io/github/deathcap/MyPlugin.java:26: error: cannot find symbol
[ERROR] @Subscribe
[ERROR] ^
[ERROR] 
[ERROR] could not parse error message:   symbol:   class Subscribe
[ERROR] location: class MyPlugin
[ERROR] /Users/admin/minecraft/SampleSpongePlugin/src/main/java/io/github/deathcap/MyPlugin.java:31: error: cannot find symbol
[ERROR] @Subscribe
[ERROR] ^
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
```
